### PR TITLE
Fix typo in Docker Hub link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,7 +37,7 @@ link = "https://github.com/rileyschuit/"
 name = "GitHub"
 
 [[params.handles]]
-link = "https://hub.docker.com/rileyschuit"
+link = "https://hub.docker.com/u/rileyschuit"
 name = "Docker"
 
 # [[params.handles]]


### PR DESCRIPTION
Because /u/ are awesome.  <3